### PR TITLE
README: Specify version of Sphinx required.

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -2,7 +2,7 @@ This is the Greybus Specification.
 
 Requirements:
 
-- Sphinx: http://sphinx-doc.org/contents.html
+- Sphinx (Version 1.4): http://sphinx-doc.org/contents.html
 - LaTeX (and pdflatex, and various LaTeX packages)
 - Graphviz (in particular, "dot"): http://www.graphviz.org/
 - Mscgen: http://www.mcternan.me.uk/mscgen/
@@ -10,7 +10,7 @@ Requirements:
 
 On Ubuntu:
 
-# apt-get install python-sphinx texlive texlive-latex-extra texlive-humanities graphviz mscgen imagemagick librsvg2-bin
+# apt-get install texlive texlive-latex-extra texlive-humanities graphviz mscgen imagemagick librsvg2-bin; pip install Sphinx==1.4
 
 Then:
 


### PR DESCRIPTION
Specifies the required version of Sphinx and amend the requirement installation command.

This is because Sphinx versions >1.4 no longer work for this spec, (`SmartyPantsHTMLTranslator` is renamed and implemented differently, along with other changes). 
Versions older than 1.4 don't compile either.